### PR TITLE
Fix url template tags (and readme) for django 1.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,7 +243,7 @@ Profile Delete Auth Type
 
 This is a default feature of django-socialauth, and is available using::
 
-    {% url socialauth_disconnect user_social_auth.provider %}
+    {% url 'socialauth_disconnect' user_social_auth.provider %}
 
 ... in a template.
 

--- a/socialprofile/templates/socialprofile/sp_account_select.html
+++ b/socialprofile/templates/socialprofile/sp_account_select.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load url from future %}
 {% block header %}{% endblock %}
 {% block page_role %}id="sp-login-modal" data-role="dialog"{% endblock %}
 {% block content %}
@@ -7,13 +8,13 @@
         <h1>{% trans 'Sign In' %}</h1>
     </div>
     <div data-role="content" data-theme="c" title="{% trans 'Sign In' %}">
-        <a href="{% url socialauth_begin 'google-oauth2' %}{% if next_url and next_param %}?{{ next_param }}={{ next_url }}{% endif %}"
+        <a href="{% url 'socialauth_begin' 'google-oauth2' %}{% if next_url and next_param %}?{{ next_param }}={{ next_url }}{% endif %}"
            id="sp-google-button" data-ajax="false" data-role="button" data-theme="b" data-icon="custom"
            data-iconshadow="false">{% trans "Google" %}</a>
-        <a href="{% url socialauth_begin 'twitter' %}{% if next_url and next_param %}?{{ next_param }}={{ next_url }}{% endif %}"
+        <a href="{% url 'socialauth_begin' 'twitter' %}{% if next_url and next_param %}?{{ next_param }}={{ next_url }}{% endif %}"
            id="sp-twitter-button" data-ajax="false" data-role="button" data-theme="b" data-icon="custom"
            data-iconshadow="false">{% trans "Twitter" %}</a>
-        <a href="{% url socialauth_begin 'facebook' %}{% if next_url and next_param %}?{{ next_param }}={{ next_url }}{% endif %}"
+        <a href="{% url 'socialauth_begin' 'facebook' %}{% if next_url and next_param %}?{{ next_param }}={{ next_url }}{% endif %}"
            id="sp-facebook-button" data-ajax="false" data-role="button" data-theme="b" data-icon="custom"
            data-iconshadow="false">{% trans "Facebook" %}</a>
     </div>

--- a/socialprofile/templates/socialprofile/sp_delete_account_modal.html
+++ b/socialprofile/templates/socialprofile/sp_delete_account_modal.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load url from future %}
 {% block header %}{% endblock %}
 {% block page_role %}data-role="dialog"{% endblock %}
 {% block content %}
@@ -7,10 +8,10 @@
         <h1>{% trans 'Really Delete?' %}</h1>
     </div>
     <div data-role="content" data-theme="c" title="{% trans 'Really Delete?' %}">
-        <a href="{% url sp_profile_edit_page %}" data-role="button" data-theme="b">{% trans "Keep Account" %}</a>
+        <a href="{% url 'sp_profile_edit_page' %}" data-role="button" data-theme="b">{% trans "Keep Account" %}</a>
         <br>
 
-        <form action="{% url sp_delete_page %}" method="post" data-ajax="false">
+        <form action="{% url 'sp_delete_page' %}" method="post" data-ajax="false">
             {% csrf_token %}
             <input type="submit" data-theme="e" data-mini="true" value="{% trans 'Delete Account & All Data' %}">
         </form>

--- a/socialprofile/templates/socialprofile/sp_profile_edit.html
+++ b/socialprofile/templates/socialprofile/sp_profile_edit.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load socialprofile_tags %}
+{% load url from future %}
 
 {% block headtitle %}{% trans "Profile for " %}{{ user.username }}{% endblock %}
 
 {% block header %}
     <header data-role="header" data-theme="b" data-position="fixed">
-        <a href="{% url sp_profile_view_page %}?returnTo={{ form.returnTo.value }}"
+        <a href="{% url 'sp_profile_view_page' %}?returnTo={{ form.returnTo.value }}"
            data-role="button">{% trans "Cancel" %}</a>
 
         <h1 class="ui-title">{% trans "Profile" %}</h1>
@@ -19,7 +20,7 @@
         {% if user.social_profile.image_url %}
             <img src="{{ user.social_profile.image_url }}"/>
         {% endif %}
-        <form action="{%  url sp_profile_edit_page %}" method="post" id="sp-profile-form" data-ajax="false">
+        <form action="{% url 'sp_profile_edit_page' %}" method="post" id="sp-profile-form" data-ajax="false">
             {% csrf_token %}
             <ul>
                 {{ form.as_ul }}
@@ -34,10 +35,10 @@
         {% else %}
             <ul>
                 {% for user_social_auth in user.social_auth.all %}
-                    <a href="{% url socialauth_disconnect user_social_auth.provider %}"
+                    <a href="{% url 'socialauth_disconnect' user_social_auth.provider %}"
                        data-role="button">{% trans "Disconnect" %} {{ user_social_auth.provider|social_provider_name }}</a>
                 {% endfor %}
-                <li><a href="{% url sp_select_page %}" data-theme="a" data-rel="dialog"
+                <li><a href="{% url 'sp_select_page' %}" data-theme="a" data-rel="dialog"
                        data-role="button">{% trans "Add Social Connection" %}</a></li>
             </ul>
 
@@ -46,6 +47,6 @@
         <br>
         <br>
         <br>
-        <a href="{% url sp_delete_page %}" data-role="button" data-theme="e">{% trans "Delete Account" %}</a>
+        <a href="{% url 'sp_delete_page' %}" data-role="button" data-theme="e">{% trans "Delete Account" %}</a>
     </section>
 {% endblock %}

--- a/socialprofile/templates/socialprofile/sp_profile_view.html
+++ b/socialprofile/templates/socialprofile/sp_profile_view.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load socialprofile_tags %}
+{% load url from future %}
 
 {% block headtitle %}{% trans "Profile for " %}{{ user.username }}{% endblock %}
 
@@ -11,7 +12,7 @@
 
         <h1>{% trans "Profile" %}</h1>
         {% if request.user.username == form.username.value %}
-            <a href="{% url sp_profile_edit_page %}?returnTo={{ form.returnTo.value }}" data-role="button"
+            <a href="{% url 'sp_profile_edit_page' %}?returnTo={{ form.returnTo.value }}" data-role="button"
                data-mini="true" data-ajax="false">{% trans "Edit" %}</a>
         {% endif %}
     </header>

--- a/socialprofile_demo/templates/header.html
+++ b/socialprofile_demo/templates/header.html
@@ -1,13 +1,14 @@
+{% load url from future %}
 <header data-role="header" data-theme="b" data-position="fixed">
     <div data-role="navbar">
         <ul>
             {% if user.is_authenticated %}
-                <li><a href="{% url sp_demo_home_page %}" data-icon="home">Home</a></li>
-                <li><a href="{% url sp_profile_view_page %}?returnTo={{ request.path }}" data-icon="gear">Profile</a></li>
-                <li><a href="{% url sp_logout_page %}" data-icon="delete">Sign Out</a></li>
+                <li><a href="{% url 'sp_demo_home_page' %}" data-icon="home">Home</a></li>
+                <li><a href="{% url 'sp_profile_view_page' %}?returnTo={{ request.path }}" data-icon="gear">Profile</a></li>
+                <li><a href="{% url 'sp_logout_page' %}" data-icon="delete">Sign Out</a></li>
             {% else %}
-                <li><a href="{% url sp_demo_home_page %}" data-icon="home">Home</a></li>
-                <li><a href="{% url sp_select_page %}" data-icon="save">Sign In</a></li>
+                <li><a href="{% url 'sp_demo_home_page' %}" data-icon="home">Home</a></li>
+                <li><a href="{% url 'sp_select_page' %}" data-icon="save">Sign In</a></li>
             {% endif %}
         </ul>
     </div>

--- a/socialprofile_demo/templates/index.html
+++ b/socialprofile_demo/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block headtitle %}Django Social Profiles Demo - Home{% endblock %}
 
@@ -18,10 +19,10 @@
             <p>If you don't have an account yet, signing in with one of those methods will create one for you.</p>
 
             <p>You can edit your profile or delete your account at any time.</p>
-            <a href="{% url sp_demo_secure_page %}" data-role="button" data-ajax="false">Get Started</a>
+            <a href="{% url 'sp_demo_secure_page' %}" data-role="button" data-ajax="false">Get Started</a>
         {% else %}
             <h2>Thank you for signing in, {{ user.username }}.</h2>
-            <a href="{% url sp_demo_secure_page %}" data-role="button" data-ajax="false">Return to Secure Area</a>
+            <a href="{% url 'sp_demo_secure_page' %}" data-role="button" data-ajax="false">Return to Secure Area</a>
         {% endif %}
     </section>
 {% endblock %}

--- a/socialprofile_demo/templates/secure.html
+++ b/socialprofile_demo/templates/secure.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block headtitle %}Secure Area{% endblock %}
 
@@ -14,6 +15,6 @@
 
         <p>Click the "Profile" button above to view and edit your profile.</p>
 
-        <p>There is <a href="{% url sp_demo_secure_page_too %}">another secure page</a> you can visit as well.</p>
+        <p>There is <a href="{% url 'sp_demo_secure_page_too' %}">another secure page</a> you can visit as well.</p>
     </section>
 {% endblock %}

--- a/socialprofile_demo/templates/securetoo.html
+++ b/socialprofile_demo/templates/securetoo.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 
 {% block headtitle %}Secure Area{% endblock %}
 
@@ -10,6 +11,6 @@
     <section title="Welcome" data-role="content">
         <h2>Welcome to the SECOND secure area.</h2>
 
-        <p>Return to the <a href="{% url sp_demo_secure_page %}">main secure page.</a></p>
+        <p>Return to the <a href="{% url 'sp_demo_secure_page' %}">main secure page.</a></p>
     </section>
 {% endblock %}


### PR DESCRIPTION
In Django 1.5 urls like {% url myurl %} must now be {% url 'myurl' %} or else django will spit out NoReverseMatch errors such as:

NoReverseMatch at /socialprofile/edit/
'url' requires a non-empty first argument. The syntax changed in Django 1.5, see the docs.

This patch converts the urls in the templates and adds {% load url from future %} for backwards compatibility with Django 1.3/1.4

Tested on django 1.4 and django 1.5
